### PR TITLE
JSON Ouptut formatting fix

### DIFF
--- a/GHDorker/file_parsing.py
+++ b/GHDorker/file_parsing.py
@@ -65,9 +65,8 @@ def output_json_file(data, filename):
 
   logger.debug("Writing JSON File: %s", filename)
   with open(filename, "+w", encoding="UTF-8") as outfile:
-    for entry in data:
-      json.dump(entry, outfile)
-      outfile.write("\n")
+    json.dump(data, outfile, indent = 4)
+
 
 
 def output_csv_file(data, filename):


### PR DESCRIPTION
Fixing the issue #12 where the JSON file output isn't a valid JSON list. Switched from looping the list to solely relying on builtin json.dump()